### PR TITLE
Fix: Improper adding to stackDepth, which causes unit test failed

### DIFF
--- a/Fluid-HTNCPP/Contexts/BaseContext.h
+++ b/Fluid-HTNCPP/Contexts/BaseContext.h
@@ -120,7 +120,9 @@ public:
         ArrayType<int> stackDepth(_WorldStateChangeStackArray.size());
         for (size_t i = 0; i < _WorldStateChangeStackArray.size(); i++)
         {
-            stackDepth.Add((int)_WorldStateChangeStackArray[i].size());
+            //stackDepth.Add((int)_WorldStateChangeStackArray[i].size());
+            // Nodifyed by kaminaritukane@163.com, to pass the DomainTests
+            stackDepth[i] = (int)_WorldStateChangeStackArray[i].size();
         }
         return stackDepth;
     }

--- a/Fluid-HTNCPP/CoreIncludes/BaseDomainBuilder.h
+++ b/Fluid-HTNCPP/CoreIncludes/BaseDomainBuilder.h
@@ -38,7 +38,7 @@ public:
     // ========================================================= HIERARCHY HANDLING
 
     /// <summary>
-    ///     Compound tasks are where HTN get their “hierarchical” nature. You can think of a compound task as
+    ///     Compound tasks are where HTN get their hierarchical nature. You can think of a compound task as
     ///     a high level task that has multiple ways of being accomplished. There are primarily two types of
     ///     compound tasks. Selectors and Sequencers. A Selector must be able to decompose a single sub-task,
     ///     while a Sequence must be able to decompose all its sub-tasks successfully for itself to have decomposed
@@ -69,7 +69,7 @@ public:
     }
     template<typename T>
     bool AddCompoundTask(StringType name)
-	{
+    {
         SharedPtr<CompoundTask> ptr = MakeSharedPtr<T>(name);
         return AddCompoundTask(name, ptr);
     };


### PR DESCRIPTION
## Description
Fixed some issues I found when I tested this project.

Fixes # (issue)
1. In BaseContext.h, there was a improper adding to stackDepth, which causes unit test failed (FindPlanClearsStateChangeWhenPlanIsNull_ExpectedBehavior)
2. When opening BaseDomainBuilder.h in Visual Studio 2022, windows 10, there was a warning about Unicode characters

## How Has This Been Tested?

1. In windows 10, open Fluid-HTN.sln --> there was a popup window showing warning about Unicode Characters
2. Build the hold solution, then run Unit Tests --> Test failed on Fluid-HTNCPP.UnitTests - DomainTests - FindPlanClearsStateChangeWhenPlanIsNull_ExpectedBehavior
